### PR TITLE
implement FilterInterface.

### DIFF
--- a/command/list/command.go
+++ b/command/list/command.go
@@ -5,12 +5,20 @@ import (
 	"fmt"
 	"os"
 
+	"../../common"
 	"../../config"
 )
 
 type Command struct {
-	VpcName string
-	VpcId   string
+	*common.InstanceFilter
+}
+
+func GetCommand() *Command {
+	return &Command{
+		&common.InstanceFilter{
+			VpcId: "",
+		},
+	}
 }
 
 func (c *Command) Help() string {
@@ -19,7 +27,10 @@ func (c *Command) Help() string {
 
 func (c *Command) Run(args []string) int {
 	c.parseOptions(args)
-	return ShowEc2Instances(os.Stdout)
+	return ShowEc2Instances(
+		os.Stdout,
+		common.InstancesFilter(c),
+	)
 }
 
 func (c *Command) Synopsis() string {
@@ -30,11 +41,9 @@ func (c *Command) parseOptions(args []string) {
 	var configPath string
 
 	f := flag.NewFlagSet("list", flag.ExitOnError)
-	f.StringVar(&c.VpcName, "vpc-name", "", "vpc name")
+	f.StringVar(&c.VpcId, "vpc-id", "", "vpc id")
 	f.StringVar(&configPath, "c", "~/.ec2s.toml", "config path")
 	f.Parse(args)
-
-	fmt.Println(c.VpcName)
 
 	_, err := config.LoadConfig(configPath)
 	if err != nil {

--- a/command/list/logic.go
+++ b/command/list/logic.go
@@ -17,10 +17,6 @@ import (
 // Sample Code
 // https://github.com/aws/aws-sdk-go/blob/7e9078c250876f26da48aaf36b8dce6a462ecd8a/service/ec2/examples_test.go#L2876
 
-func describeParams() *ec2.DescribeInstancesInput {
-	return &ec2.DescribeInstancesInput{}
-}
-
 func vpcId(instance *ec2.Instance) string {
 	if instance.VPCID == nil {
 		return ""
@@ -38,7 +34,7 @@ func loadVpcCache() *cache.VpcCache {
 	}
 }
 
-func ShowEc2Instances(writer io.Writer) int {
+func ShowEc2Instances(writer io.Writer, filter *ec2.DescribeInstancesInput) int {
 	vpcCache := loadVpcCache()
 	if vpcCache == nil {
 		fmt.Println("failed to make vpc cache..")
@@ -47,7 +43,7 @@ func ShowEc2Instances(writer io.Writer) int {
 	instanceCache := cache.GetEc2InstanceCache()
 
 	service := common.Ec2Service()
-	res, err := service.DescribeInstances(describeParams())
+	res, err := service.DescribeInstances(filter)
 
 	if err != nil {
 		fmt.Println("failed...")

--- a/command/ssh/command.go
+++ b/command/ssh/command.go
@@ -7,10 +7,21 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
+	"../../common"
 	"../../config"
 )
 
-type Command struct{}
+type Command struct {
+	*common.InstanceFilter
+}
+
+func GetCommand() *Command {
+	return &Command{
+		&common.InstanceFilter{
+			VpcId: "",
+		},
+	}
+}
 
 func (c *Command) Help() string {
 	return "ec2s ssh"
@@ -18,7 +29,9 @@ func (c *Command) Help() string {
 
 func (c *Command) Run(args []string) int {
 	c.parseOptions(args)
-	instances, ret := c.choseInstance()
+	instances, ret := c.choseInstance(
+		common.InstancesFilter(c),
+	)
 	if ret != 0 {
 		return ret
 	}
@@ -50,6 +63,7 @@ func (c *Command) parseOptions(args []string) {
 	var configPath string
 
 	f := flag.NewFlagSet("ssh", flag.ExitOnError)
+	f.StringVar(&c.VpcId, "vpc-id", "", "vpc id")
 	f.StringVar(&configPath, "c", "~/.ec2s.toml", "config path")
 	f.Parse(args)
 

--- a/command/ssh/logic.go
+++ b/command/ssh/logic.go
@@ -17,8 +17,8 @@ import (
 	"../list"
 )
 
-func listEc2Instances(writer io.Writer) int {
-	return list.ShowEc2Instances(writer)
+func listEc2Instances(writer io.Writer, filter *ec2.DescribeInstancesInput) int {
+	return list.ShowEc2Instances(writer, filter)
 }
 
 func ec2instance(line string) *ec2.Instance {
@@ -39,9 +39,9 @@ func ec2instance(line string) *ec2.Instance {
 	return instance
 }
 
-func (c *Command) choseInstance() ([]*ec2.Instance, int) {
+func (c *Command) choseInstance(filter *ec2.DescribeInstancesInput) ([]*ec2.Instance, int) {
 	buffer := bytes.NewBuffer(nil)
-	listEc2Instances(buffer)
+	listEc2Instances(buffer, filter)
 
 	conf := config.GetConfig()
 

--- a/command/vpcs/command.go
+++ b/command/vpcs/command.go
@@ -8,9 +8,10 @@ import (
 	"../../config"
 )
 
-type Command struct {
-	VpcName string
-	VpcId   string
+type Command struct{}
+
+func GetCommand() *Command {
+	return &Command{}
 }
 
 func (c *Command) Help() string {

--- a/common/filter.go
+++ b/common/filter.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type InstanceFilter struct {
+	VpcId string
+}
+
+type FilterInterface interface {
+	VpcFilter() *ec2.Filter
+}
+
+func (filter *InstanceFilter) VpcFilter() *ec2.Filter {
+	if len(filter.VpcId) == 0 {
+		return nil
+	}
+
+	return &ec2.Filter{
+		Name: aws.String("vpc-id"),
+		Values: []*string{
+			aws.String(filter.VpcId),
+		},
+	}
+}
+
+func InstancesFilter(options FilterInterface) *ec2.DescribeInstancesInput {
+	filters := []*ec2.Filter{}
+
+	vpcFilter := options.VpcFilter()
+	if vpcFilter != nil {
+		filters = append(filters, vpcFilter)
+	}
+
+	return &ec2.DescribeInstancesInput{
+		Filters: filters,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,13 +18,13 @@ func main() {
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
 		"list": func() (cli.Command, error) {
-			return &list.Command{}, nil
+			return list.GetCommand(), nil
 		},
 		"vpcs": func() (cli.Command, error) {
-			return &vpcs.Command{}, nil
+			return vpcs.GetCommand(), nil
 		},
 		"ssh": func() (cli.Command, error) {
-			return &ssh.Command{}, nil
+			return ssh.GetCommand(), nil
 		},
 	}
 


### PR DESCRIPTION
Introduce FilterInterface to enable vpc-id filter on `list`, `ssh` subcommands.

```
$ ec2s list -vpc-id vpc-xxxx

$ ec2s ssh -vpc-id vpc-xxxx
```
