### PR TITLE
Fixed import paths

### DIFF
--- a/cache/vpc.go
+++ b/cache/vpc.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"../common"
+	"github.com/hirakiuc/ec2s/common"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 )

--- a/chooser/ec2_chooser.go
+++ b/chooser/ec2_chooser.go
@@ -7,10 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"gopkg.in/pipe.v2"
 
-	"../cache"
-	"../command/list"
-	"../common"
-	"../config"
+	"github.com/hirakiuc/ec2s/cache"
+	"github.com/hirakiuc/ec2s/command/list"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 var logger *common.Logger

--- a/command/elbs/command.go
+++ b/command/elbs/command.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"os"
 
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 type Command struct{}

--- a/command/elbs/logic.go
+++ b/command/elbs/logic.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/elb"
 
-	"../../cache"
-	"../../common"
-	"../../formatter"
+	"github.com/hirakiuc/ec2s/cache"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/formatter"
 )
 
 func loadVpcCache() error {

--- a/command/list/command.go
+++ b/command/list/command.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"os"
 
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 type Command struct {

--- a/command/list/logic.go
+++ b/command/list/logic.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"../../cache"
-	"../../common"
-	"../../formatter"
+	"github.com/hirakiuc/ec2s/cache"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/formatter"
 )
 
 // Reference Code

--- a/command/scp/command.go
+++ b/command/scp/command.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"../../chooser"
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/chooser"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 type Command struct {

--- a/command/scp/logic.go
+++ b/command/scp/logic.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 func (c *Command) logCommand(instance *ec2.Instance, privateKeyPath *string, fromPath string, toPath string) {

--- a/command/ssh/command.go
+++ b/command/ssh/command.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"../../chooser"
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/chooser"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 type Command struct {

--- a/command/ssh/logic.go
+++ b/command/ssh/logic.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 func (c *Command) logCommand(instance *ec2.Instance, privateKeyPath *string) {

--- a/command/vpcs/command.go
+++ b/command/vpcs/command.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"os"
 
-	"../../common"
-	"../../config"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/config"
 )
 
 type Command struct{}

--- a/command/vpcs/logic.go
+++ b/command/vpcs/logic.go
@@ -3,8 +3,8 @@ package vpcs
 import (
 	"io"
 
-	"../../common"
-	"../../formatter"
+	"github.com/hirakiuc/ec2s/common"
+	"github.com/hirakiuc/ec2s/formatter"
 )
 
 func (c *Command) showVpcs(writer io.Writer) error {

--- a/common/aws_service.go
+++ b/common/aws_service.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"../config"
+	"github.com/hirakiuc/ec2s/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/formatter/util.go
+++ b/formatter/util.go
@@ -1,7 +1,7 @@
 package formatter
 
 import (
-	"../cache"
+	"github.com/hirakiuc/ec2s/cache"
 )
 
 const UNDEFINED = "---"

--- a/main.go
+++ b/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"os"
 
-	"./command/elbs"
-	"./command/list"
-	"./command/scp"
-	"./command/ssh"
-	"./command/vpcs"
-	"./common"
+	"github.com/hirakiuc/ec2s/command/elbs"
+	"github.com/hirakiuc/ec2s/command/list"
+	"github.com/hirakiuc/ec2s/command/scp"
+	"github.com/hirakiuc/ec2s/command/ssh"
+	"github.com/hirakiuc/ec2s/command/vpcs"
+	"github.com/hirakiuc/ec2s/common"
 
 	"github.com/mitchellh/cli"
 )


### PR DESCRIPTION
Using relative import paths should be avoided unless you have solid reason to use it, it will break "go get" etc.
