### PR TITLE
Add ArgumentError.

### DIFF
--- a/internal/command/scp/command.go
+++ b/internal/command/scp/command.go
@@ -99,8 +99,10 @@ func (c *Command) parseOptions(args []string) error {
 	logger.SetColored(conf.Common.ColorizedOutput)
 
 	if f.NArg() != 2 {
+		err := common.NewArgumentError("Require two arguments.")
+		common.ShowError(err)
 		f.Usage()
-		os.Exit(1) // TODO: fix to return error.
+		return err
 	}
 
 	c.FromPath = f.Arg(0)

--- a/internal/common/error.go
+++ b/internal/common/error.go
@@ -4,12 +4,29 @@ import (
 	"fmt"
 )
 
+// ArgumentError describe a error that receiver passed invalid arguments.
+type ArgumentError struct {
+	Cause string
+}
+
+// NewArgumentError create ArgumentError instance.
+func NewArgumentError(msg string) ArgumentError {
+	return ArgumentError{
+		Cause: msg,
+	}
+}
+
+// Error return error message
+func (err ArgumentError) Error() string {
+	return fmt.Sprintf("Argument Error: %s", err.Cause)
+}
+
 // VpcNotFoundError describe a error that  Vpc not found.
 type VpcNotFoundError struct {
 	Cause string
 }
 
 // Error return error message
-func (err *VpcNotFoundError) Error() string {
+func (err VpcNotFoundError) Error() string {
 	return fmt.Sprintf("No such vpc found. %s", err.Cause)
 }


### PR DESCRIPTION
Add ArgumentError to remove TODO comment in `internal/command/scp/command.go`.
