### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,25 @@
+name: Checks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  checkes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: ./go.mod
+        check-latest: true
+        cache: true
+
+    - name: Make check
+      run:
+        make check
+
+    - name: Make build
+      run:
+        make build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .DEFAULT_GOAL := default
 
+.PHONY: build, deps, install, check, clean, default
+
 build:
 	go build
+
+deps:
+	go mod tidy
+	go mod vendor
 
 install:
 	go install


### PR DESCRIPTION
# WHAT

- Enable GitHub Actions.

# WHY

- Need to migrate the CI because wercker will shutdown in near future. 

https://devcenter.wercker.com/
> Important Notice: Wercker service will be shutdown on October 31st, 2022 . 