### PR TITLE
Enable golangci lint checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,10 +16,6 @@ jobs:
         check-latest: true
         cache: true
 
-    - name: Make check
-      run:
-        make check
-
     - name: Make build
       run:
         make build

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,17 @@
+name: reviewdog
+
+on:
+  pull_request:
+
+jobs:
+  golangci-lint:
+    name: lint checks by using golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          golangci_lint_version: 1.46.2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,4 +14,4 @@ jobs:
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
-          golangci_lint_version: 1.46.2
+          golangci_lint_version: v1.46.2

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	go install
 
 check:
-	go vet . ./internal/...
+	golangci-lint run ./...
 
 clean:
 	go clean

--- a/internal/cache/vpc.go
+++ b/internal/cache/vpc.go
@@ -11,8 +11,10 @@ type VpcCache struct {
 	Entries map[string]*ec2.Vpc
 }
 
-var vpcCache *VpcCache
-var logger *common.Logger
+var (
+	vpcCache *VpcCache
+	logger   *common.Logger
+)
 
 func init() {
 	logger = common.GetLogger()
@@ -41,16 +43,22 @@ func (cache *VpcCache) WriteEntry(vpcID string, vpc *ec2.Vpc) {
 
 // MakeCache create Vpc Cache
 func (cache *VpcCache) MakeCache() error {
-	service := common.Ec2Service()
+	service, err := common.Ec2Service()
+	if err != nil {
+		return err
+	}
+
 	res, err := service.DescribeVpcs(nil)
 	if err != nil {
 		logger.Error("failed to make vpcs cache.\n")
+
 		return err
 	}
 
 	for _, vpc := range res.Vpcs {
 		cache.WriteEntry(*vpc.VpcId, vpc)
 	}
+
 	return nil
 }
 

--- a/internal/command/elbs/logic.go
+++ b/internal/command/elbs/logic.go
@@ -24,12 +24,17 @@ func (c *Command) showElbs(writer io.Writer) error {
 		return err
 	}
 
-	service := common.ElbService()
+	service, err := common.ElbService()
+	if err != nil {
+		return err
+	}
 
 	params := &elb.DescribeLoadBalancersInput{}
+
 	res, err := service.DescribeLoadBalancers(params)
 	if err != nil {
 		logger.Error("failed to fetch elbs.\n")
+
 		return err
 	}
 
@@ -41,5 +46,6 @@ func (c *Command) showElbs(writer io.Writer) error {
 	}
 
 	table.Render()
+
 	return nil
 }

--- a/internal/command/list/logic.go
+++ b/internal/command/list/logic.go
@@ -39,9 +39,14 @@ func ShowEc2Instances(writer io.Writer, options common.FilterInterface) error {
 	if err != nil {
 		return err
 	}
+
 	instanceCache := cache.GetEc2InstanceCache()
 
-	service := common.Ec2Service()
+	service, err := common.Ec2Service()
+	if err != nil {
+		return err
+	}
+
 	params, err := options.InstancesFilter()
 	if err != nil {
 		return err
@@ -50,6 +55,7 @@ func ShowEc2Instances(writer io.Writer, options common.FilterInterface) error {
 	res, err := service.DescribeInstances(params)
 	if err != nil {
 		logger.Error("failed to load EC2 instances.\n")
+
 		return err
 	}
 
@@ -69,5 +75,6 @@ func ShowEc2Instances(writer io.Writer, options common.FilterInterface) error {
 	}
 
 	table.Render()
+
 	return nil
 }

--- a/internal/command/scp/logic.go
+++ b/internal/command/scp/logic.go
@@ -57,8 +57,7 @@ func (c *Command) execScp(instance *ec2.Instance) error {
 		return err
 	}
 
-	cmd.Wait()
-	return nil
+	return cmd.Wait()
 }
 
 func expandPath(path string, instance *ec2.Instance) string {

--- a/internal/command/ssh/logic.go
+++ b/internal/command/ssh/logic.go
@@ -53,6 +53,5 @@ func (c *Command) execSSH(instance *ec2.Instance) error {
 		return err
 	}
 
-	cmd.Wait()
-	return nil
+	return cmd.Wait()
 }

--- a/internal/command/version/command.go
+++ b/internal/command/version/command.go
@@ -13,11 +13,9 @@ const VERSION string = "0.1.0"
 // Command describe version command.
 type Command struct{}
 
-var logger *common.Logger
 var command Command
 
 func init() {
-	logger = common.GetLogger()
 	command = Command{}
 
 	_, err := options.AddCommand(

--- a/internal/command/vpcs/logic.go
+++ b/internal/command/vpcs/logic.go
@@ -8,10 +8,15 @@ import (
 )
 
 func (c *Command) showVpcs(writer io.Writer) error {
-	service := common.Ec2Service()
+	service, err := common.Ec2Service()
+	if err != nil {
+		return err
+	}
+
 	res, err := service.DescribeVpcs(nil)
 	if err != nil {
 		logger.Error("failed to fetch vpcs.\n")
+
 		return err
 	}
 
@@ -23,5 +28,6 @@ func (c *Command) showVpcs(writer io.Writer) error {
 	}
 
 	table.Render()
+
 	return nil
 }

--- a/internal/common/aws_service.go
+++ b/internal/common/aws_service.go
@@ -13,33 +13,46 @@ import (
 )
 
 // ElbService is a aws Elb client.
-func ElbService() *elb.ELB {
+func ElbService() (*elb.ELB, error) {
 	conf := config.GetConfig()
 
+	awsSession, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
 	return elb.New(
-		session.New(),
+		awsSession,
 		&aws.Config{
 			Region:      aws.String(conf.Aws.Region),
 			Credentials: conf.AwsCredentials(),
 		},
-	)
+	), nil
 }
 
 // Ec2Service is a aws EC2 client.
-func Ec2Service() *ec2.EC2 {
+func Ec2Service() (*ec2.EC2, error) {
 	conf := config.GetConfig()
 
+	awsSession, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
 	return ec2.New(
-		session.New(),
+		awsSession,
 		&aws.Config{
 			Region:      aws.String(conf.Aws.Region),
 			Credentials: conf.AwsCredentials(),
 		},
-	)
+	), nil
 }
 
 func findVpcs(params *ec2.DescribeVpcsInput) ([]*ec2.Vpc, error) {
-	service := Ec2Service()
+	service, err := Ec2Service()
+	if err != nil {
+		return []*ec2.Vpc{}, err
+	}
 
 	res, err := service.DescribeVpcs(params)
 	if err != nil {

--- a/internal/common/text_formatter.go
+++ b/internal/common/text_formatter.go
@@ -11,11 +11,7 @@ type TextFormatter struct {
 
 func colorForLogLevel(level LogLevel) string {
 	switch level {
-	case PanicLevel:
-		return "red"
-	case FatalLevel:
-		return "red"
-	case ErrorLevel:
+	case PanicLevel, FatalLevel, ErrorLevel:
 		return "red"
 	case WarnLevel:
 		return "yellow"
@@ -30,10 +26,11 @@ func colorForLogLevel(level LogLevel) string {
 
 // Format return formatted string.
 func (f *TextFormatter) Format(level LogLevel, message string) ([]byte, error) {
-	if f.Colored == false {
+	if !f.Colored {
 		return []byte(message), nil
 	}
 
 	msg := ansi.Color(message, colorForLogLevel(level))
+
 	return []byte(msg), nil
 }

--- a/internal/formatter/ec2_formatter.go
+++ b/internal/formatter/ec2_formatter.go
@@ -21,19 +21,6 @@ func nameOfInstance(instance *ec2.Instance) string {
 	return UNDEFINED
 }
 
-func vpcName(vpc *ec2.Vpc) string {
-	if vpc == nil {
-		return UNDEFINED
-	}
-
-	for _, t := range vpc.Tags {
-		if *t.Key == "Name" {
-			return *t.Value
-		}
-	}
-	return UNDEFINED
-}
-
 func ipAddress(instance *ec2.Instance) string {
 	if instance.PublicIpAddress != nil {
 		return *instance.PublicIpAddress

--- a/main.go
+++ b/main.go
@@ -9,15 +9,8 @@ import (
 	_ "github.com/hirakiuc/ec2s/internal/command/ssh"
 	_ "github.com/hirakiuc/ec2s/internal/command/version"
 	_ "github.com/hirakiuc/ec2s/internal/command/vpcs"
-	"github.com/hirakiuc/ec2s/internal/common"
 	"github.com/hirakiuc/ec2s/internal/options"
 )
-
-var logger *common.Logger
-
-func init() {
-	logger = common.GetLogger()
-}
 
 func main() {
 	if _, err := options.ParseOptions(); err != nil {


### PR DESCRIPTION
# WHAT

- Use golangci-lint, instead
- fix lint issues
- fix codes which uses deprecated methods

# WHY

- Improvements
